### PR TITLE
Add basic Jest tests and ESLint setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "env": {
+    "es2021": true,
+    "node": true,
+    "jest": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "rules": {}
+}

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,40 @@
+process.env.HELIUS_RPC_URL = 'https://example.com';
+process.env.KEYPAIR_ENCRYPTION_KEY = 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+jest.mock('../src/lib/raydium', () => ({ SOL_MINT: 'So11111111111111111111111111111111111111112' }));
+jest.mock('chalk', () => ({ default: {} }));
+jest.mock('@metaplex-foundation/umi-bundle-defaults', () => ({
+  createUmi: () => ({ use: () => ({}) }),
+}));
+jest.mock('@metaplex-foundation/mpl-token-metadata', () => ({ mplTokenMetadata: () => ({}) }));
+
+import swapExample from '../src/data/example-pumpfun-swap.json';
+import tokenTx from '../src/data/example-token-tx.json';
+import { getTransactionDataFromWebhookTransaction, findTokenMintAddressFromTransaction, getTokenPriceInSolFromTransaction } from '../src/lib/utils';
+import { ParsedTransactionWithMeta } from '@solana/web3.js';
+
+
+describe('utils', () => {
+  test('parses webhook transaction', () => {
+    const data = getTransactionDataFromWebhookTransaction(swapExample as any);
+    expect(data).toBeDefined();
+    expect(data?.tokenMint).toBe('2Ya8S3FPkaqu8ji6PaxKMSpJEdYYkbyax8eZMDkvpump');
+    expect(data?.solAmount).toBeCloseTo(0.05);
+    expect(data?.tokenAmount).toBeCloseTo(1071707.852766);
+    expect(data?.isBuy).toBe(true);
+    expect(data?.isSell).toBe(false);
+    expect(data?.price).toBeCloseTo(0.05 / 1071707.852766);
+  });
+
+  test('finds token mint', () => {
+    const mint = findTokenMintAddressFromTransaction(tokenTx as unknown as ParsedTransactionWithMeta);
+    expect(mint).toBe('12UP9cSwe1tDzQg3KSEx1BpSS9nkpT5VkmDe4fSz4Hso');
+  });
+
+  test('calculates token price', () => {
+    const priceInfo = getTokenPriceInSolFromTransaction(tokenTx as unknown as ParsedTransactionWithMeta, true);
+    expect(priceInfo).toBeDefined();
+    expect(priceInfo?.solSpent).toBeCloseTo(4.95);
+    expect(priceInfo?.tokensReceived).toBeCloseTo(2679024.146408);
+    expect(priceInfo?.pricePerToken).toBeCloseTo(4.95 / 2679024.146408);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "NODE_ENV=production tsx src/index.ts & tsx src/discord.ts",
     "dev": "tsx src/index.ts & tsx src/discord.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest",
+    "lint": "eslint . --ext .ts"
   },
   "keywords": [],
   "author": "",
@@ -34,6 +35,13 @@
   "devDependencies": {
     "@types/bn.js": "^5.1.6",
     "@types/express": "^4.17.21",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "@types/node": "^20.11.30",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.10",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^7.6.0",
+    "@typescript-eslint/parser": "^7.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest for TypeScript projects
- set up ESLint and lint script
- write unit tests for transaction helpers

## Testing
- `npm test --silent`
- `npm run lint` *(fails: 110 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68725c13bcf0832089aa1f900f934cfa