### PR TITLE
Enhance pump.fun monitoring and add trade log

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Moonbot Token Sniper Bot is a sophisticated tool designed for the Solana blockch
 - **Database Management:** Utilizes PostgreSQL to store and manage token data, signals, and user invite codes.
 - **Encryption:** Encrypts sensitive information such as keypairs using AES-256-CBC encryption for enhanced security.
 - **Retry Mechanism:** Implements robust retry logic for transaction submissions to handle network or API failures gracefully.
+- **Pump.fun Monitoring:** Fetches new Pump.fun launches and filters them by liquidity, volume, age, and blocklists.
+- **Trade Logging:** Records every buy and sell in the `trade_log` table for easy profit tracking.
 
 ## Architecture
 

--- a/schema.sql
+++ b/schema.sql
@@ -120,6 +120,23 @@ CREATE TABLE public.token_prices (
 ALTER TABLE public.token_prices OWNER TO postgres;
 
 --
+-- Name: trade_log; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.trade_log (
+    id serial PRIMARY KEY,
+    token_mint character varying(80),
+    trade_type character varying(4),
+    price double precision,
+    amount double precision,
+    gain_loss double precision,
+    "timestamp" bigint
+);
+
+
+ALTER TABLE public.trade_log OWNER TO postgres;
+
+--
 -- Name: token_signals; Type: TABLE; Schema: public; Owner: postgres
 --
 

--- a/src/lib/autoSell.ts
+++ b/src/lib/autoSell.ts
@@ -1,0 +1,31 @@
+import { Connection, Keypair, PublicKey } from "@solana/web3.js"
+
+export interface AutoSellConfig {
+  takeProfitX?: number[] // e.g. [2,5]
+  stopLoss?: number // e.g. 0.5 meaning 50% drop
+}
+
+// Placeholder for automatic sell logic using Jupiter aggregator
+export const autoSellToken = async (
+  connection: Connection,
+  keypair: Keypair,
+  tokenMint: PublicKey,
+  currentPrice: number,
+  entryPrice: number,
+  cfg: AutoSellConfig
+) => {
+  const gain = currentPrice / entryPrice
+  if (cfg.stopLoss && gain <= cfg.stopLoss) {
+    // TODO: integrate Jupiter swap for stop loss
+    return "STOP_LOSS"
+  }
+  if (cfg.takeProfitX) {
+    for (const x of cfg.takeProfitX) {
+      if (gain >= x) {
+        // TODO: integrate Jupiter swap for take profit
+        return `TP_${x}`
+      }
+    }
+  }
+  return null
+}

--- a/src/lib/postgres.ts
+++ b/src/lib/postgres.ts
@@ -80,6 +80,16 @@ export type SignalWithEntry = {
   entry_source: string
 }
 
+export type TradeLogRow = {
+  id: number
+  token_mint: string
+  trade_type: "BUY" | "SELL"
+  price: number
+  amount: number
+  gain_loss: number | null
+  timestamp: number
+}
+
 
 export const getSignals = async (maxHoursOld = 24) => {
   console.time("signals query")
@@ -274,6 +284,23 @@ export const insertPoolAddress = async (token: string, poolAddress: string) => {
             INSERT INTO pool_addresses (token, pool_address)
             VALUES (${token}, ${poolAddress})
         `
+
+  return res[0]
+}
+
+export const insertTradeLog = async (
+  tokenMint: string,
+  tradeType: "BUY" | "SELL",
+  price: number,
+  amount: number,
+  gainLoss: number | null,
+  timestamp: number
+) => {
+  const res = await sql<TradeLogRow[]>`
+    INSERT INTO trade_log (token_mint, trade_type, price, amount, gain_loss, "timestamp")
+    VALUES (${tokenMint}, ${tradeType}, ${price}, ${amount}, ${gainLoss}, ${timestamp})
+    RETURNING *
+  `
 
   return res[0]
 }

--- a/src/lib/pumpfun.ts
+++ b/src/lib/pumpfun.ts
@@ -25,6 +25,7 @@ import {
   MEMO_PROGRAM_ID,
 } from "@raydium-io/raydium-sdk"
 import chalk from "chalk"
+import { insertTradeLog } from "./postgres"
 
 const connection = new Connection(heliusRpcUrl, {
   confirmTransactionInitialTimeout: 1 * 80 * 1000,
@@ -213,6 +214,15 @@ export const getBuyPumpfunTokenTransaction = async (
 
       versionedTransaction.sign([keypair])
 
+      await insertTradeLog(
+        tokenMint.toString(),
+        "BUY",
+        virtualTokenPrice,
+        finalAmount,
+        null,
+        Date.now()
+      )
+
       return versionedTransaction.serialize()
 
       // const txid = await connection.sendRawTransaction(
@@ -373,6 +383,14 @@ export const getSellPumpfunTokenTransaction = async (
             JSON.stringify(simulated.value.err)
         )
       } else {
+        await insertTradeLog(
+          tokenMint.toString(),
+          "SELL",
+          virtualTokenPrice,
+          amount,
+          null,
+          Date.now()
+        )
         return versionedTransaction.serialize()
       }
     } catch (e) {

--- a/src/lib/pumpfunDiscover.ts
+++ b/src/lib/pumpfunDiscover.ts
@@ -1,0 +1,53 @@
+export interface LaunchFilter {
+  minLiquidity?: number
+  minVolume?: number
+  maxAgeMinutes?: number
+  blocklist?: string[]
+}
+
+export interface PumpFunLaunch {
+  mint: string
+  liquidity: number
+  volume: number
+  createdAt: number
+}
+
+// Fetch recent Pump.fun launches and apply optional filters
+export const fetchPumpfunLaunches = async (
+  filters: LaunchFilter = {}
+): Promise<PumpFunLaunch[]> => {
+  const res = await fetch('https://frontend-api.pump.fun/projects?limit=50')
+  if (!res.ok) {
+    throw new Error('Pump.fun API error')
+  }
+  const data = await res.json()
+  const now = Date.now()
+
+  const projects = (data.projects || []) as any[]
+  return projects
+    .map((p) => ({
+      mint: p.mintAddress as string,
+      liquidity: Number(p.liquiditySol) || 0,
+      volume: Number(p.volume24h) || 0,
+      createdAt: Number(p.createdTime) * 1000,
+    }))
+    .filter((p) => {
+      if (filters.blocklist && filters.blocklist.includes(p.mint)) {
+        return false
+      }
+      if (filters.minLiquidity && p.liquidity < filters.minLiquidity) {
+        return false
+      }
+      if (filters.minVolume && p.volume < filters.minVolume) {
+        return false
+      }
+      if (
+        filters.maxAgeMinutes &&
+        now - p.createdAt > filters.maxAgeMinutes * 60 * 1000
+      ) {
+        return false
+      }
+      return true
+    })
+}
+

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1019,3 +1019,31 @@ export type PairData = {
   pairCreatedAt: number
   info: TokenImage
 }
+
+// Approximate dev wallet share using Helius API
+export const checkDevWalletShare = async (
+  mint: string
+): Promise<number | null> => {
+  try {
+    const url = `https://api.helius.xyz/v0/tokens/${mint}?api-key=${process.env.HELIUS_API_KEY}`
+    const res = await fetch(url)
+    if (!res.ok) return null
+    const data = await res.json()
+    return Number(data?.devShare) || null
+  } catch {
+    return null
+  }
+}
+
+// Check if LP tokens are locked using Birdeye public API
+export const checkLpLocked = async (mint: string): Promise<boolean> => {
+  try {
+    const url = `https://public-api.birdeye.so/defi/token/${mint}`
+    const res = await fetch(url)
+    if (!res.ok) return false
+    const data = await res.json()
+    return Boolean(data?.data?.isLpLocked)
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- document pump.fun monitoring and trade logging
- add `trade_log` table in schema
- log buys and sells in `insertTradeLog`
- support trade logging in pumpfun transactions
- expose dev wallet and LP lock checks
- fetch new pump.fun launches with filters
- stub automatic sell logic

## Testing
- `apt-get update`
- `apt-get install -y nodejs`
- `apt-get install -y npm` *(failed: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68725f0c50e88320bc52cb181eb38aaf